### PR TITLE
fix detect CocosCreator as Cocos2dx

### DIFF
--- a/config.json
+++ b/config.json
@@ -46,14 +46,6 @@
             },
 
             {
-                "name": "Cocos2d-x",
-                "file_name_keywords": [],
-                "file_content_keywords": ["CCRender"],
-                "sub_types":{},
-                "engine_version_keyword": "cocos2d-x[\\s-](\\d+\\..*?)\\0"
-            },
-
-            {
                 "name": "unity",
                 "file_name_keywords": ["libunity\\.so", "unity3d", "unityengine", "unityscript"],
                 "file_content_keywords": ["mono_unity", "unity3d", "unityengine", "unityscript"],
@@ -119,6 +111,15 @@
                 "file_name_keywords": ["libgodot_android\\.so$"],
                 "file_content_keywords": [],
                 "sub_types": {}
+            }
+        ],
+        [
+            {
+                "name": "Cocos2d-x",
+                "file_name_keywords": [],
+                "file_content_keywords": ["CCRender"],
+                "sub_types":{},
+                "engine_version_keyword": "cocos2d-x[\\s-](\\d+\\..*?)\\0"
             }
         ],
         [


### PR DESCRIPTION
- 修复 CocosCreator 可能被检测为 Cocos2dx 的问题

CocosCreator 是文件名检查，Cocos2dx 是文件内容检查，会冲突
同时 Cocos2dx 还不能提供太多的其他关键字，否则就会跟 +Cocos 冲突